### PR TITLE
Re-enable PaRSEC backend profiling, and extend it to comms.

### DIFF
--- a/ttg/ttg/parsec/ttg_data_copy.h
+++ b/ttg/ttg/parsec/ttg_data_copy.h
@@ -422,7 +422,10 @@ namespace ttg_parsec {
         return m_iovecs.size();
       }
 
-#if defined(PARSEC_PROF_TRACE) && defined(PARSEC_TTG_PROFILE_BACKEND)
+#if defined(PARSEC_PROF_TRACE)
+      //< These two fields are used by the profiling system to carry information
+      //  between the data copy creation and its destruction. They are set after
+      //  creation by the profiling system, iff profiling is enabled.
       int64_t size;
       int64_t uid;
 #endif


### PR DESCRIPTION
All change are in the parsec backend:
 - Remove the compile-level PARSEC_PROF_BACKEND which had to be defined/undefined by hand in the code
 - Port old profiling style to new profiling style
 - Create a send_msg function that does all the book-keeping when doing a parsec_ce.send_am from TTG; use only that function from the rest of the code
 - Extend the backend profiling events to log communications